### PR TITLE
Allow whitelist/blacklist for "next event"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,23 @@ $ cp sample.env .env
 
 # Install dependencies
 $ pipenv install
+
+# Copy a configuration file and edit
+cp sample.env .env
 ```
+
+### Configuration
+
+The following things can be set via environment variable (and in the
+`.env` file):
+
+- `MEETUP_API_KEY` (required)
+- `MEETUP_GROUP_SLUG`: The group to work with. (required) Example:
+  `Civic-Tech-Toronto`
+- `MEETUP_EVENT_NAME_WHITELIST`. A comma-separated list of strings. This
+  will be used to find the next event, via case-insensitive match on
+Meetup event titles. Example: `hacknight, hack night`
+
 
 ### Run
 

--- a/sample.env
+++ b/sample.env
@@ -4,5 +4,8 @@ MEETUP_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # From the url of your group
 MEETUP_GROUP_SLUG=Civic-Tech-Toronto
 
+# Comma-separated list of case-insensitive strings to match on.
+MEETUP_EVENT_NAME_WHITELIST=""
+
 # Set another if 5000 is already in use
 PORT=5000

--- a/settings.py
+++ b/settings.py
@@ -5,4 +5,5 @@ load_dotenv(dotenv_path='.env')
 
 MEETUP_API_KEY = os.getenv('MEETUP_API_KEY')
 MEETUP_GROUP_SLUG = os.getenv('MEETUP_GROUP_SLUG')
+MEETUP_EVENT_NAME_WHITELIST = os.getenv('MEETUP_EVENT_NAME_WHITELIST', "")
 PORT = os.getenv('PORT', 5000)


### PR DESCRIPTION
Right now, we send the invite list for the very next event, but we've now started using meetup for monthly organizer meetings (Mondays), so that will confuse the matter. We could add a whitelist or blacklist envvar for patterns to match in event title.

We might want to write that in fine-print on the website itself, if only to make the setting documented for future organizers who might come to rely on it.